### PR TITLE
Fix unit tests and add them to the Gitlab config

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,8 @@ include:
 Unit Test:
   image: quay.io/ebi-ait/ingest-base-images:python_3.6-slim
   script:
+    - apt-get update
+    - apt-get install -y git
     - pip install -r requirements.txt
     - INGEST_API=https://api.ingest.dev.archive.data.humancellatlas.org
     - nosetests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,5 +4,6 @@ include:
 Unit Test:
   image: quay.io/ebi-ait/ingest-base-images:python_3.6-slim
   script:
+    - pip install -r requirements.txt
     - INGEST_API=https://api.ingest.dev.archive.data.humancellatlas.org
     - nosetests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,5 +8,4 @@ Unit Test:
     - apt-get install -y git
     - pip install -r requirements.txt
     - pip install -r requirements-dev.txt
-    - INGEST_API=https://api.ingest.dev.archive.data.humancellatlas.org
     - nosetests --processes=-1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,5 +7,6 @@ Unit Test:
     - apt-get update
     - apt-get install -y git
     - pip install -r requirements.txt
+    - pip install -r requirements-dev.txt
     - INGEST_API=https://api.ingest.dev.archive.data.humancellatlas.org
     - nosetests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,4 +9,4 @@ Unit Test:
     - pip install -r requirements.txt
     - pip install -r requirements-dev.txt
     - INGEST_API=https://api.ingest.dev.archive.data.humancellatlas.org
-    - nosetests
+    - nosetests --processes=-1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,2 +1,8 @@
 include:
   remote: 'https://raw.githubusercontent.com/ebi-ait/gitlab-ci-templates/master/build-release-deploy.yml'
+
+Unit Test:
+  image: quay.io/ebi-ait/ingest-base-images:python_3.6-slim
+  script:
+    - INGEST_API=https://api.ingest.dev.archive.data.humancellatlas.org
+    - nosetests

--- a/broker/service/summary_service.py
+++ b/broker/service/summary_service.py
@@ -102,7 +102,7 @@ class SummaryService:
         return submission_summary
 
     def get_entities_in_submission(self, submission_uri, entity_type) -> Generator[dict, None, None]:
-        yield from self.ingestapi.getEntities(submission_uri, entity_type, 1000)
+        yield from self.ingestapi.get_entities(submission_uri, entity_type)
 
     def get_all_entities_in_submission(self, submission_uri):
         return SubmissionEntities(list(self.get_entities_in_submission(submission_uri, 'biomaterials')),

--- a/broker/service/summary_service.py
+++ b/broker/service/summary_service.py
@@ -112,7 +112,7 @@ class SummaryService:
                                   list(self.get_entities_in_submission(submission_uri, 'files')))
 
     def get_submissions_in_project(self, project_resource) -> Generator[dict, None, None]:
-        yield from self.ingestapi.getRelatedEntities('submissionEnvelopes', project_resource, 'submissionEnvelopes')
+        yield from self.ingestapi.get_related_entities('submissionEnvelopes', project_resource, 'submissionEnvelopes')
 
     @staticmethod
     def generate_summary_for_entity(entities) -> EntitySummary:

--- a/broker_app.py
+++ b/broker_app.py
@@ -46,9 +46,9 @@ Nothing else for you to do - check back later."
 
 SPREADSHEET_UPLOAD_MESSAGE_ERROR = "We experienced a problem while uploading your spreadsheet"
 
-ingest_api = IngestApi()
-spreadsheet_generator = SpreadsheetGenerator(ingest_api)
-spreadsheet_job_manager = SpreadsheetJobManager(spreadsheet_generator, SPREADSHEET_STORAGE_DIR)
+global ingest_api
+global spreadsheet_generator
+global spreadsheet_job_manager
 
 
 @app.route('/', methods=['GET'])
@@ -182,6 +182,7 @@ def get_spreadsheet(job_id: str):
             mimetype='application/json'
         )
 
+
 # TODO Currently, we also have schema endpoints in Ingest Core and technically this can be implemented there
 # Those endpoints could also be removed from core and have a separate schema service for retrieving information about
 # the metadata schema and integrated with the schema release process
@@ -286,7 +287,18 @@ def response_json(status_code, data):
     return response
 
 
-if __name__ == '__main__':
+def setup():
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+    global ingest_api
+    global spreadsheet_generator
+    global spreadsheet_job_manager
+
+    ingest_api = IngestApi()
+    spreadsheet_generator = SpreadsheetGenerator(ingest_api)
+    spreadsheet_job_manager = SpreadsheetJobManager(spreadsheet_generator, SPREADSHEET_STORAGE_DIR)
+
+if __name__ == '__main__':
+    setup()
 
     app.run(host='0.0.0.0', port=5000)

--- a/test/service/test_spreadsheet_generator.py
+++ b/test/service/test_spreadsheet_generator.py
@@ -14,6 +14,7 @@ import yaml
 
 class TestSpreadsheetGenerator(TestCase):
 
+    @skip("This is an integration test")
     def test_link_column_generation(self):
         cell_suspension_spec = TypeSpec("cell_suspension", IncludeAllModules(), False, LinkSpec(["donor_organism"], []))
 
@@ -65,6 +66,7 @@ class TestSpreadsheetGenerator(TestCase):
 
         self.assertEqual(spreadsheet_spec.hashcode(), SpreadsheetSpec.from_dict(spreadsheet_spec_dict).hashcode())
 
+    @skip("This is an integration test")
     def test_template_tabs_from_parsed_tabs(self):
         test_type_spec_1 = TypeSpec("project", IncludeAllModules(), False, LinkSpec([], []))
         test_type_spec_2 = TypeSpec("imaged_specimen", IncludeAllModules(), True, LinkSpec([], ["imaging_protocol"]))
@@ -95,6 +97,7 @@ class TestSpreadsheetGenerator(TestCase):
         self.assertTrue("Project" in [tab.display_name for tab in template_tabs])
         self.assertTrue(any("specimen_from_organism.biomaterial_core.biomaterial_id" in cols for cols in [tab.columns for tab in template_tabs]))
 
+    @skip("This is an integration test")
     def test_user_friendly_names(self):
         ingest_url = "https://api.ingest.dev.archive.data.humancellatlas.org"
         ingest_api = IngestApi(ingest_url)
@@ -159,6 +162,7 @@ class TestSpreadsheetGenerator(TestCase):
 
         self.assertFalse(name_error)
 
+    @skip("This is an integration test")
     def test_generate(self):
         ingest_url = "https://api.ingest.dev.archive.data.humancellatlas.org"
         ingest_api = IngestApi(ingest_url)

--- a/test/test_broker_app.py
+++ b/test/test_broker_app.py
@@ -15,12 +15,15 @@ class BrokerAppTest(TestCase):
                     super(BrokerAppTest, self).run(result)
 
 
+    @patch('broker_app.SpreadsheetJobManager')
     @patch('broker_app.SpreadsheetGenerator')
     @patch('broker_app.IngestApi')
-    def test_setup(self, mock_ingest, mock_spreadsheet_generator):
+    def test_setup(self, mock_ingest, mock_spreadsheet_generator, mock_spreadsheet_manager):
         setup()
         mock_ingest.assert_called_once()
         mock_spreadsheet_generator.assert_called_once_with(mock_ingest())
+        mock_spreadsheet_manager.assert_called_once_with(mock_spreadsheet_generator(mock_ingest()), None)
+
 
     @patch('broker_app.os.environ')
     @patch('broker_app.IngestApi')

--- a/test/test_broker_app.py
+++ b/test/test_broker_app.py
@@ -81,7 +81,6 @@ class BrokerAppTest(TestCase):
         with self.request_context:
             with patch.object(broker_app, "request") as mock_request:
                 # given
-                mock_request = patch.object(flask, "request")
                 mock_request.files = {'file': 'content'.encode()}
                 mock_request.form = {}
                 mock_headers = Mock('headers')

--- a/test/test_broker_app.py
+++ b/test/test_broker_app.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, Mock
 
 from broker.service.spreadsheet_upload_service import SpreadsheetUploadError
 from broker_app import app as _app, setup
+import flask, broker_app
 
 
 class BrokerAppTest(TestCase):
@@ -10,8 +11,8 @@ class BrokerAppTest(TestCase):
     @patch('broker_app.IngestApi')
     def setUp(self, mock_ingest, mock_spreadsheet_generator):
         setup()
-        _app.testing = True
         self.app = _app.test_client()
+        self.request_context = _app.test_request_context()
 
     @patch('broker_app.os.environ')
     @patch('broker_app.IngestApi')
@@ -34,116 +35,122 @@ class BrokerAppTest(TestCase):
         # then
         self.assertEqual(response.status_code, 302)
 
-    @patch('broker_app.request')
     @patch('broker_app.SpreadsheetUploadService.async_upload')
     @patch('broker_app.IngestApi')
-    def test_upload_success(self, mock_ingest, mock_async_upload, mock_request):
-        # given
-        mock_async_upload.return_value = {'uuid': {'uuid': 'uuid'}, '_links': {'self': {'href': 'url/9'}}}
-        mock_request.files = {'file': 'content'.encode()}
-        mock_request.form = {}
-        mock_headers = Mock('headers')
-        mock_headers.get = Mock(return_value='token')
-        mock_request.headers = mock_headers
+    def test_upload_success(self, mock_ingest, mock_async_upload):
+        with self.request_context:
+            with patch.object(broker_app, "request") as mock_request:
+                mock_async_upload.return_value = {'uuid': {'uuid': 'uuid'}, '_links': {'self': {'href': 'url/9'}}}
+                mock_request.files = {'file': 'content'.encode()}
+                mock_request.form = {}
+                mock_headers = Mock('headers')
+                mock_headers.get = Mock(return_value='token')
+                mock_request.headers = mock_headers
 
-        # when
-        response = self.app.post('/api_upload')
+                # when
+                response = self.app.post('/api_upload')
 
-        # then
-        self.assertEqual(response.status_code, 201)
-        self.assertRegex(str(response.data), 'url/9')
-        mock_async_upload.assert_called_with('token', 'content'.encode(), False, None)
+                # then
+                self.assertEqual(response.status_code, 201)
+                self.assertRegex(str(response.data), 'url/9')
+                mock_async_upload.assert_called_with('token', 'content'.encode(), False, None)
 
-    @patch('broker_app.request')
     @patch('broker_app.SpreadsheetUploadService.async_upload')
     @patch('broker_app.IngestApi')
-    def test_upload_error(self, mock_ingest, mock_async_upload, mock_request):
-        # given
-        mock_async_upload.side_effect = SpreadsheetUploadError(500, 'message', 'details')
-        mock_request.files = {'file': 'content'.encode()}
-        mock_request.form = {}
-        mock_headers = Mock('headers')
-        mock_headers.get = Mock(return_value='token')
-        mock_request.headers = mock_headers
+    def test_upload_error(self, mock_ingest, mock_async_upload):
+        with self.request_context:
+            with patch.object(broker_app, "request") as mock_request:
+                # given
+                mock_async_upload.side_effect = SpreadsheetUploadError(500, 'message', 'details')
+                mock_request.files = {'file': 'content'.encode()}
+                mock_request.form = {}
+                mock_headers = Mock('headers')
+                mock_headers.get = Mock(return_value='token')
+                mock_request.headers = mock_headers
 
-        # when
-        response = self.app.post('/api_upload')
+                # when
+                response = self.app.post('/api_upload')
 
-        # then
-        self.assertEqual(response.status_code, 500)
-        self.assertRegex(str(response.data), 'message')
-        mock_async_upload.assert_called_with('token', 'content'.encode(), False, None)
+                # then
+                self.assertEqual(response.status_code, 500)
+                self.assertRegex(str(response.data), 'message')
+                mock_async_upload.assert_called_with('token', 'content'.encode(), False, None)
 
-    @patch('broker_app.request')
     @patch('broker_app.IngestApi')
-    def test_upload_unauthorized(self, mock_ingest, mock_request):
-        # given
-        mock_request.files = {'file': 'content'.encode()}
-        mock_request.form = {}
-        mock_headers = Mock('headers')
-        mock_headers.get = Mock(return_value=None)
-        mock_request.headers = mock_headers
+    def test_upload_unauthorized(self, mock_ingest):
+        with self.request_context:
+            with patch.object(broker_app, "request") as mock_request:
+                # given
+                mock_request = patch.object(flask, "request")
+                mock_request.files = {'file': 'content'.encode()}
+                mock_request.form = {}
+                mock_headers = Mock('headers')
+                mock_headers.get = Mock(return_value=None)
+                mock_request.headers = mock_headers
 
-        # when
-        response = self.app.post('/api_upload')
+                # when
+                response = self.app.post('/api_upload')
 
-        # then
-        self.assertEqual(response.status_code, 401)
-        self.assertRegex(str(response.data), 'authentication')
+                # then
+                self.assertEqual(response.status_code, 401)
+                self.assertRegex(str(response.data), 'authentication')
 
-    @patch('broker_app.request')
     @patch('broker_app.SpreadsheetUploadService.async_upload')
     @patch('broker_app.IngestApi')
-    def test_upload_update_success(self, mock_ingest, mock_async_upload, mock_request):
-        # given
-        mock_async_upload.return_value = {'uuid': {'uuid': 'uuid'}, '_links': {'self': {'href': 'url/9'}}}
-        mock_request.files = {'file': 'content'.encode()}
-        mock_request.form = {}
-        mock_headers = Mock('headers')
-        mock_headers.get = Mock(return_value='token')
-        mock_request.headers = mock_headers
+    def test_upload_update_success(self, mock_ingest, mock_async_upload):
+        with self.request_context:
+            with patch.object(broker_app, "request") as mock_request:
+                # given
+                mock_async_upload.return_value = {'uuid': {'uuid': 'uuid'}, '_links': {'self': {'href': 'url/9'}}}
+                mock_request.files = {'file': 'content'.encode()}
+                mock_request.form = {}
+                mock_headers = Mock('headers')
+                mock_headers.get = Mock(return_value='token')
+                mock_request.headers = mock_headers
 
-        # when
-        response = self.app.post('/api_upload_update')
+                # when
+                response = self.app.post('/api_upload_update')
 
-        # then
-        self.assertEqual(response.status_code, 201)
-        self.assertRegex(str(response.data), 'url/9')
-        mock_async_upload.assert_called_with('token', 'content'.encode(), True, None)
+                # then
+                self.assertEqual(response.status_code, 201)
+                self.assertRegex(str(response.data), 'url/9')
+                mock_async_upload.assert_called_with('token', 'content'.encode(), True, None)
 
-    @patch('broker_app.request')
     @patch('broker_app.SpreadsheetUploadService.async_upload')
     @patch('broker_app.IngestApi')
-    def test_upload_update_error(self, mock_ingest, mock_async_upload, mock_request):
-        # given
-        mock_async_upload.side_effect = SpreadsheetUploadError(500, 'message', 'details')
-        mock_request.files = {'file': 'content'.encode()}
-        mock_request.form = {}
-        mock_headers = Mock('headers')
-        mock_headers.get = Mock(return_value='token')
-        mock_request.headers = mock_headers
+    def test_upload_update_error(self, mock_ingest, mock_async_upload):
+        with self.request_context:
+            with patch.object(broker_app, "request") as mock_request:
+                # given
+                mock_async_upload.side_effect = SpreadsheetUploadError(500, 'message', 'details')
+                mock_request.files = {'file': 'content'.encode()}
+                mock_request.form = {}
+                mock_headers = Mock('headers')
+                mock_headers.get = Mock(return_value='token')
+                mock_request.headers = mock_headers
 
-        # when
-        response = self.app.post('/api_upload_update')
+                # when
+                response = self.app.post('/api_upload_update')
 
-        # then
-        self.assertEqual(response.status_code, 500)
-        self.assertRegex(str(response.data), 'message')
-        mock_async_upload.assert_called_with('token', 'content'.encode(), True, None)
+                # then
+                self.assertEqual(response.status_code, 500)
+                self.assertRegex(str(response.data), 'message')
+                mock_async_upload.assert_called_with('token', 'content'.encode(), True, None)
 
-    @patch('broker_app.request')
     @patch('broker_app.IngestApi')
-    def test_upload_update_unauthorized(self, mock_ingest, mock_request):
-        # given
-        mock_request.files = {'file': 'content'.encode()}
-        mock_request.form = {}
-        mock_headers = Mock('headers')
-        mock_headers.get = Mock(return_value=None)
-        mock_request.headers = mock_headers
+    def test_upload_update_unauthorized(self, mock_ingest):
+        with self.request_context:
+            with patch.object(broker_app, "request") as mock_request:
+                # given
+                mock_request.files = {'file': 'content'.encode()}
+                mock_request.form = {}
+                mock_headers = Mock('headers')
+                mock_headers.get = Mock(return_value=None)
+                mock_request.headers = mock_headers
 
-        # when
-        response = self.app.post('/api_upload_update')
+                # when
+                response = self.app.post('/api_upload_update')
 
-        # then
-        self.assertEqual(response.status_code, 401)
-        self.assertRegex(str(response.data), 'authentication')
+                # then
+                self.assertEqual(response.status_code, 401)
+                self.assertRegex(str(response.data), 'authentication')

--- a/test/test_broker_app.py
+++ b/test/test_broker_app.py
@@ -1,18 +1,23 @@
-from unittest import TestCase
+from unittest import TestCase, skip
 from unittest.mock import patch, Mock
 
 from broker.service.spreadsheet_upload_service import SpreadsheetUploadError
 from broker_app import app as _app, setup
-import flask, broker_app
-
+import broker_app
 
 class BrokerAppTest(TestCase):
     @patch('broker_app.SpreadsheetGenerator')
     @patch('broker_app.IngestApi')
     def setUp(self, mock_ingest, mock_spreadsheet_generator):
         setup()
-        self.app = _app.test_client()
-        self.request_context = _app.test_request_context()
+
+    def run(self, result=None):
+        with _app.test_request_context():
+            with _app.test_client() as client:
+                with patch.object(broker_app, "request") as mock_request:
+                    self.mock_request = mock_request
+                    self.app = client
+                    super(BrokerAppTest, self).run(result)
 
     @patch('broker_app.os.environ')
     @patch('broker_app.IngestApi')
@@ -27,7 +32,6 @@ class BrokerAppTest(TestCase):
     @patch('broker_app.os.environ')
     @patch('broker_app.IngestApi')
     def test_index_redirect(self, mock_ingest, mock_env):
-        app = _app.test_client()
         # given
         mock_env.get.return_value = 'url'
         # when:
@@ -38,118 +42,106 @@ class BrokerAppTest(TestCase):
     @patch('broker_app.SpreadsheetUploadService.async_upload')
     @patch('broker_app.IngestApi')
     def test_upload_success(self, mock_ingest, mock_async_upload):
-        with self.request_context:
-            with patch.object(broker_app, "request") as mock_request:
-                mock_async_upload.return_value = {'uuid': {'uuid': 'uuid'}, '_links': {'self': {'href': 'url/9'}}}
-                mock_request.files = {'file': 'content'.encode()}
-                mock_request.form = {}
-                mock_headers = Mock('headers')
-                mock_headers.get = Mock(return_value='token')
-                mock_request.headers = mock_headers
+        mock_async_upload.return_value = {'uuid': {'uuid': 'uuid'}, '_links': {'self': {'href': 'url/9'}}}
+        self.mock_request.files = {'file': 'content'.encode()}
+        self.mock_request.form = {}
+        mock_headers = Mock('headers')
+        mock_headers.get = Mock(return_value='token')
+        self.mock_request.headers = mock_headers
 
-                # when
-                response = self.app.post('/api_upload')
+        # when
+        response = self.app.post('/api_upload')
 
-                # then
-                self.assertEqual(response.status_code, 201)
-                self.assertRegex(str(response.data), 'url/9')
-                mock_async_upload.assert_called_with('token', 'content'.encode(), False, None)
+        # then
+        self.assertEqual(response.status_code, 201)
+        self.assertRegex(str(response.data), 'url/9')
+        mock_async_upload.assert_called_with('token', 'content'.encode(), False, None)
 
     @patch('broker_app.SpreadsheetUploadService.async_upload')
     @patch('broker_app.IngestApi')
     def test_upload_error(self, mock_ingest, mock_async_upload):
-        with self.request_context:
-            with patch.object(broker_app, "request") as mock_request:
-                # given
-                mock_async_upload.side_effect = SpreadsheetUploadError(500, 'message', 'details')
-                mock_request.files = {'file': 'content'.encode()}
-                mock_request.form = {}
-                mock_headers = Mock('headers')
-                mock_headers.get = Mock(return_value='token')
-                mock_request.headers = mock_headers
+        # given
+        mock_async_upload.side_effect = SpreadsheetUploadError(500, 'message', 'details')
+        self.mock_request.files = {'file': 'content'.encode()}
+        self.mock_request.form = {}
+        mock_headers = Mock('headers')
+        mock_headers.get = Mock(return_value='token')
+        self.mock_request.headers = mock_headers
 
-                # when
-                response = self.app.post('/api_upload')
+        # when
+        response = self.app.post('/api_upload')
 
-                # then
-                self.assertEqual(response.status_code, 500)
-                self.assertRegex(str(response.data), 'message')
-                mock_async_upload.assert_called_with('token', 'content'.encode(), False, None)
+        # then
+        self.assertEqual(response.status_code, 500)
+        self.assertRegex(str(response.data), 'message')
+        mock_async_upload.assert_called_with('token', 'content'.encode(), False, None)
 
     @patch('broker_app.IngestApi')
     def test_upload_unauthorized(self, mock_ingest):
-        with self.request_context:
-            with patch.object(broker_app, "request") as mock_request:
-                # given
-                mock_request.files = {'file': 'content'.encode()}
-                mock_request.form = {}
-                mock_headers = Mock('headers')
-                mock_headers.get = Mock(return_value=None)
-                mock_request.headers = mock_headers
+        # given
+        self.mock_request.files = {'file': 'content'.encode()}
+        self.mock_request.form = {}
+        mock_headers = Mock('headers')
+        mock_headers.get = Mock(return_value=None)
+        self.mock_request.headers = mock_headers
 
-                # when
-                response = self.app.post('/api_upload')
+        # when
+        response = self.app.post('/api_upload')
 
-                # then
-                self.assertEqual(response.status_code, 401)
-                self.assertRegex(str(response.data), 'authentication')
+        # then
+        self.assertEqual(response.status_code, 401)
+        self.assertRegex(str(response.data), 'authentication')
 
     @patch('broker_app.SpreadsheetUploadService.async_upload')
     @patch('broker_app.IngestApi')
     def test_upload_update_success(self, mock_ingest, mock_async_upload):
-        with self.request_context:
-            with patch.object(broker_app, "request") as mock_request:
-                # given
-                mock_async_upload.return_value = {'uuid': {'uuid': 'uuid'}, '_links': {'self': {'href': 'url/9'}}}
-                mock_request.files = {'file': 'content'.encode()}
-                mock_request.form = {}
-                mock_headers = Mock('headers')
-                mock_headers.get = Mock(return_value='token')
-                mock_request.headers = mock_headers
+        # given
+        mock_async_upload.return_value = {'uuid': {'uuid': 'uuid'}, '_links': {'self': {'href': 'url/9'}}}
+        self.mock_request.files = {'file': 'content'.encode()}
+        self.mock_request.form = {}
+        mock_headers = Mock('headers')
+        mock_headers.get = Mock(return_value='token')
+        self.mock_request.headers = mock_headers
 
-                # when
-                response = self.app.post('/api_upload_update')
+        # when
+        response = self.app.post('/api_upload_update')
 
-                # then
-                self.assertEqual(response.status_code, 201)
-                self.assertRegex(str(response.data), 'url/9')
-                mock_async_upload.assert_called_with('token', 'content'.encode(), True, None)
+        # then
+        self.assertEqual(response.status_code, 201)
+        self.assertRegex(str(response.data), 'url/9')
+        mock_async_upload.assert_called_with('token', 'content'.encode(), True, None)
 
     @patch('broker_app.SpreadsheetUploadService.async_upload')
     @patch('broker_app.IngestApi')
     def test_upload_update_error(self, mock_ingest, mock_async_upload):
-        with self.request_context:
-            with patch.object(broker_app, "request") as mock_request:
-                # given
-                mock_async_upload.side_effect = SpreadsheetUploadError(500, 'message', 'details')
-                mock_request.files = {'file': 'content'.encode()}
-                mock_request.form = {}
-                mock_headers = Mock('headers')
-                mock_headers.get = Mock(return_value='token')
-                mock_request.headers = mock_headers
+        # given
+        mock_async_upload.side_effect = SpreadsheetUploadError(500, 'message', 'details')
+        self.mock_request.files = {'file': 'content'.encode()}
+        self.mock_request.form = {}
+        mock_headers = Mock('headers')
+        mock_headers.get = Mock(return_value='token')
+        self.mock_request.headers = mock_headers
 
-                # when
-                response = self.app.post('/api_upload_update')
+        # when
+        response = self.app.post('/api_upload_update')
 
-                # then
-                self.assertEqual(response.status_code, 500)
-                self.assertRegex(str(response.data), 'message')
-                mock_async_upload.assert_called_with('token', 'content'.encode(), True, None)
+        # then
+        self.assertEqual(response.status_code, 500)
+        self.assertRegex(str(response.data), 'message')
+        mock_async_upload.assert_called_with('token', 'content'.encode(), True, None)
 
     @patch('broker_app.IngestApi')
     def test_upload_update_unauthorized(self, mock_ingest):
-        with self.request_context:
-            with patch.object(broker_app, "request") as mock_request:
-                # given
-                mock_request.files = {'file': 'content'.encode()}
-                mock_request.form = {}
-                mock_headers = Mock('headers')
-                mock_headers.get = Mock(return_value=None)
-                mock_request.headers = mock_headers
+        # given
+        self.mock_request.files = {'file': 'content'.encode()}
+        self.mock_request.form = {}
+        mock_headers = Mock('headers')
+        mock_headers.get = Mock(return_value=None)
+        self.mock_request.headers = mock_headers
 
-                # when
-                response = self.app.post('/api_upload_update')
+        # when
+        response = self.app.post('/api_upload_update')
 
-                # then
-                self.assertEqual(response.status_code, 401)
-                self.assertRegex(str(response.data), 'authentication')
+        # then
+        self.assertEqual(response.status_code, 401)
+        self.assertRegex(str(response.data), 'authentication')

--- a/test/test_broker_app.py
+++ b/test/test_broker_app.py
@@ -2,14 +2,14 @@ from unittest import TestCase
 from unittest.mock import patch, Mock
 
 from broker.service.spreadsheet_upload_service import SpreadsheetUploadError
-from broker_app import app as _app
+from broker_app import app as _app, setup
 
 
 class BrokerAppTest(TestCase):
-    def setUp(self):
-        # Note: IngestApi will call the API endpoint to retrieve links (see IngestApi._get_ingest_links)
-        # This should really be mocked but for now setting
-        # INGEST_API=https://api.ingest.dev.archive.data.humancellatlas.org in the env vars will fix
+    @patch('broker_app.IngestApi')
+    @patch('broker_app.SpreadsheetGenerator')
+    def setUp(self, mock_ingest, mock_spreadsheet_generator):
+        setup()
         _app.testing = True
         self.app = _app.test_client()
 

--- a/test/test_broker_app.py
+++ b/test/test_broker_app.py
@@ -6,11 +6,6 @@ from broker_app import app as _app, setup
 import broker_app
 
 class BrokerAppTest(TestCase):
-    @patch('broker_app.SpreadsheetGenerator')
-    @patch('broker_app.IngestApi')
-    def setUp(self, mock_ingest, mock_spreadsheet_generator):
-        setup()
-
     def run(self, result=None):
         with _app.test_request_context():
             with _app.test_client() as client:
@@ -18,6 +13,14 @@ class BrokerAppTest(TestCase):
                     self.mock_request = mock_request
                     self.app = client
                     super(BrokerAppTest, self).run(result)
+
+
+    @patch('broker_app.SpreadsheetGenerator')
+    @patch('broker_app.IngestApi')
+    def test_setup(self, mock_ingest, mock_spreadsheet_generator):
+        setup()
+        mock_ingest.assert_called_once()
+        mock_spreadsheet_generator.assert_called_once_with(mock_ingest())
 
     @patch('broker_app.os.environ')
     @patch('broker_app.IngestApi')

--- a/test/test_broker_app.py
+++ b/test/test_broker_app.py
@@ -7,6 +7,9 @@ from broker_app import app as _app
 
 class BrokerAppTest(TestCase):
     def setUp(self):
+        # Note: IngestApi will call the API endpoint to retrieve links (see IngestApi._get_ingest_links)
+        # This should really be mocked but for now setting
+        # INGEST_API=https://api.ingest.dev.archive.data.humancellatlas.org in the env vars will fix
         _app.testing = True
         self.app = _app.test_client()
 

--- a/test/test_broker_app.py
+++ b/test/test_broker_app.py
@@ -14,7 +14,7 @@ class BrokerAppTest(TestCase):
     def run(self, result=None):
         with _app.test_request_context():
             with _app.test_client() as client:
-                with patch.object(broker_app, "request") as mock_request:
+                with patch.object(broker_app, 'request') as mock_request:
                     self.mock_request = mock_request
                     self.app = client
                     super(BrokerAppTest, self).run(result)

--- a/test/test_broker_app.py
+++ b/test/test_broker_app.py
@@ -6,8 +6,8 @@ from broker_app import app as _app, setup
 
 
 class BrokerAppTest(TestCase):
-    @patch('broker_app.IngestApi')
     @patch('broker_app.SpreadsheetGenerator')
+    @patch('broker_app.IngestApi')
     def setUp(self, mock_ingest, mock_spreadsheet_generator):
         setup()
         _app.testing = True

--- a/test/test_broker_app.py
+++ b/test/test_broker_app.py
@@ -5,6 +5,7 @@ from broker.service.spreadsheet_upload_service import SpreadsheetUploadError
 from broker_app import app as _app, setup
 import broker_app
 
+
 class BrokerAppTest(TestCase):
     def run(self, result=None):
         with _app.test_request_context():
@@ -14,7 +15,6 @@ class BrokerAppTest(TestCase):
                     self.app = client
                     super(BrokerAppTest, self).run(result)
 
-
     @patch('broker_app.SpreadsheetJobManager')
     @patch('broker_app.SpreadsheetGenerator')
     @patch('broker_app.IngestApi')
@@ -23,7 +23,6 @@ class BrokerAppTest(TestCase):
         mock_ingest.assert_called_once()
         mock_spreadsheet_generator.assert_called_once_with(mock_ingest())
         mock_spreadsheet_manager.assert_called_once_with(mock_spreadsheet_generator(mock_ingest()), None)
-
 
     @patch('broker_app.os.environ')
     @patch('broker_app.IngestApi')


### PR DESCRIPTION
This fixes the unit tests for [#263](https://github.com/ebi-ait/dcp-ingest-central/issues/263) and sets up the gitlab runner to run them.

I did a couple of things to get tests working:
- Skipped tests that were more like Integration tests. Those making calls to Ingest API
  - These tests are using Ingest to get the schema which we could mock. However, that will cause further issues down the line since we'd have to make sure the mocks are kept up to date with schema changes. I think it would be better just to create integration tests for this.
- Refactored `broker_app` to define a setup function that is invoked when the file is executed as a script and is also invoked by the `TestCase`. This is done since `IngestAPI` starts making API calls on instantiation so we need to delay instantiation when `broker_app` is ran as a module (in the tests) so that `IngestAPI` can be mocked
- Refactored `test_broker_app` to use `test_request_context` to solve issues when mocking requests
- I also added a couple of fixes for the summary endpoints that I noticed weren't working