### PR TITLE
dcp-142 geo to hca - broker

### DIFF
--- a/broker/geo_accession/routes.py
+++ b/broker/geo_accession/routes.py
@@ -22,18 +22,20 @@ def get_spreadsheet_using_geo():
     args = request.args
     geo_accession = args.get('accession')
 
-    workbook = create_spreadsheet_using_geo_accession(geo_accession)
+    try:
+        workbook = create_spreadsheet_using_geo_accession(geo_accession)
 
-    if workbook:
-        file_stream = io.BytesIO()
-        workbook.save(file_stream)
-        file_stream.seek(0)
+        if workbook:
+            file_stream = io.BytesIO()
+            workbook.save(file_stream)
+            file_stream.seek(0)
 
-        return send_file(
-            file_stream,
-            attachment_filename=f"hca_metadata_spreadsheet-{geo_accession}.xlsx",
-            mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-            as_attachment=True,
-            cache_timeout=0
-        )
-    return response_json(HTTPStatus.NOT_FOUND, "Unable to find HCA metadata against this accession")
+            return send_file(
+                file_stream,
+                attachment_filename=f"hca_metadata_spreadsheet-{geo_accession}.xlsx",
+                mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                as_attachment=True,
+                cache_timeout=0
+            )
+    except:
+        return response_json(HTTPStatus.NOT_FOUND, "Unable to find HCA metadata against this accession")

--- a/broker/geo_accession/routes.py
+++ b/broker/geo_accession/routes.py
@@ -1,0 +1,39 @@
+# --- core imports
+from http import HTTPStatus
+import io
+
+# --- application imports
+from broker.common.util import response_json
+
+# --- third-party imports
+from flask import Blueprint, send_file, request
+from flask_cors import cross_origin
+from geo_to_hca.geo_to_hca import create_spreadsheet_using_geo_accession
+
+
+geo_accession_bp = Blueprint(
+    'geo_accession', __name__, url_prefix='/geo-accession'
+)
+
+
+@cross_origin()
+@geo_accession_bp.route("/spreadsheet")
+def get_spreadsheet_using_geo():
+    args = request.args
+    geo_accession = args.get('accession')
+
+    workbook = create_spreadsheet_using_geo_accession(geo_accession)
+
+    if workbook:
+        file_stream = io.BytesIO()
+        workbook.save(file_stream)
+        file_stream.seek(0)
+
+        return send_file(
+            file_stream,
+            attachment_filename=f"hca_metadata_spreadsheet-{geo_accession}.xlsx",
+            mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            as_attachment=True,
+            cache_timeout=0
+        )
+    return response_json(HTTPStatus.NOT_FOUND, "Unable to find HCA metadata against this accession")

--- a/broker/import_geo/routes.py
+++ b/broker/import_geo/routes.py
@@ -1,5 +1,6 @@
 # --- core imports
 from http import HTTPStatus
+import re
 import tempfile
 
 # --- application imports
@@ -10,16 +11,24 @@ from flask import Blueprint, send_file, request
 from flask_cors import cross_origin
 from geo_to_hca import geo_to_hca
 
-geo_accession_bp = Blueprint(
-    'geo_accession', __name__, url_prefix='/geo-accession'
+import_geo_bp = Blueprint(
+    'import_geo', __name__, url_prefix='/'
 )
 
 
+def is_valid_geo_accession(geo_accession):
+    regex = re.compile("^GSE.*$")
+    return bool(regex.match(geo_accession))
+
+
 @cross_origin()
-@geo_accession_bp.route("/spreadsheet")
+@import_geo_bp.route("/import-geo", methods=['POST'])
 def get_spreadsheet_using_geo():
     args = request.args
     geo_accession = args.get('accession')
+
+    if not is_valid_geo_accession(geo_accession):
+        return response_json(HTTPStatus.BAD_REQUEST, "The given geo accession is invalid")
 
     try:
         workbook = geo_to_hca.create_spreadsheet_using_geo_accession(geo_accession)

--- a/broker_app.py
+++ b/broker_app.py
@@ -35,7 +35,7 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO,
 
 def create_app():
     app = Flask(__name__, static_folder='static')
-    app.SPREADSHEET_STORAGE_DIR = os.environ.get('SPREADSHEET_STORAGE_DIR') or 'abc'
+    app.SPREADSHEET_STORAGE_DIR = os.environ.get('SPREADSHEET_STORAGE_DIR')
     app.SPREADSHEET_UPLOAD_MESSAGE = "We’ve got your spreadsheet, and we’re currently importing and validating the data. \
 Nothing else for you to do - check back later."
 
@@ -195,13 +195,12 @@ def get_schemas():
 
 
 @cross_origin()
-@app.route("/spreadsheets")
+@app.route("/spreadsheet")
 def get_spreadsheet_using_geo():
     args = request.args
     geo_accession = args.get('geo-accession')
 
     workbook = create_spreadsheet_using_geo_accession(geo_accession)
-    print(workbook)
 
     if workbook:
         file_stream = io.BytesIO()

--- a/broker_app.py
+++ b/broker_app.py
@@ -21,7 +21,7 @@ from broker.service.spreadsheet_generation.spreadsheet_job_manager import Spread
 from broker.service.summary_service import SummaryService
 from broker.submissions import submissions_bp
 from broker.upload import upload_bp
-from broker.geo_accession.routes import geo_accession_bp
+from broker.import_geo.routes import import_geo_bp
 
 logging.getLogger('ingest').setLevel(logging.INFO)
 logging.getLogger('ingest.api.ingestapi').setLevel(logging.INFO)
@@ -51,7 +51,7 @@ Nothing else for you to do - check back later."
 
     app.register_blueprint(upload_bp)
     app.register_blueprint(submissions_bp)
-    app.register_blueprint(geo_accession_bp)
+    app.register_blueprint(import_geo_bp)
 
     return app
 

--- a/broker_app.py
+++ b/broker_app.py
@@ -26,6 +26,7 @@ from broker.geo_accession.routes import geo_accession_bp
 logging.getLogger('ingest').setLevel(logging.INFO)
 logging.getLogger('ingest.api.ingestapi').setLevel(logging.INFO)
 logging.getLogger('broker.service.spreadsheet_upload_service').setLevel(logging.INFO)
+logging.getLogger('geo_to_hca').setLevel(logging.INFO)
 
 format = ' %(asctime)s  - %(name)s - %(levelname)s in %(filename)s:' \
          '%(lineno)s %(funcName)s(): %(message)s'

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ mock~=3.0.5
 dataclasses~=0.6
 argparse~=1.4.0
 jsonref~=0.2
-geo-to-hca
+geo-to-hca~=1.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ mock~=3.0.5
 dataclasses~=0.6
 argparse~=1.4.0
 jsonref~=0.2
+geo-to-hca

--- a/test/unit/geo_accession/test_new_spreadsheet_using_geo.py
+++ b/test/unit/geo_accession/test_new_spreadsheet_using_geo.py
@@ -1,0 +1,31 @@
+import unittest
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+from broker_app import app as _app
+
+
+class ExportToSpreadsheetUsingGeoTestCase(TestCase):
+
+    def setUp(self):
+        _app.testing = True
+
+    @patch('broker.geo_accession.routes.geo_to_hca.create_spreadsheet_using_geo_accession')
+    def test_export_spreadsheet_using_geo(self, mock_create_spreadsheet_using_geo_accession):
+        # given
+        mock_workbook = MagicMock()
+        mock_create_spreadsheet_using_geo_accession.return_value = mock_workbook
+        geo_accession = 'GSE001'
+
+        with _app.test_client() as app:
+            # when
+            response = app.get(f'geo-accession/spreadsheet?accession={geo_accession}')
+
+            # then
+            mock_create_spreadsheet_using_geo_accession.assert_called_with(geo_accession)
+            content_disp = response.headers.get('Content-Disposition')
+            self.assertRegex(content_disp, r'filename\=hca_metadata_spreadsheet\-GSE001.xlsx')
+            self.assertEqual(200, response.status_code)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/geo_accession/test_new_spreadsheet_using_geo.py
+++ b/test/unit/geo_accession/test_new_spreadsheet_using_geo.py
@@ -4,13 +4,29 @@ from unittest.mock import patch, MagicMock
 from broker_app import app as _app
 
 
-class ExportToSpreadsheetUsingGeoTestCase(TestCase):
+class GetSpreadsheetUsingGeoTestCase(TestCase):
 
     def setUp(self):
         _app.testing = True
 
-    @patch('broker.geo_accession.routes.geo_to_hca.create_spreadsheet_using_geo_accession')
-    def test_export_spreadsheet_using_geo(self, mock_create_spreadsheet_using_geo_accession):
+
+    @patch('broker.import_geo.routes.geo_to_hca.create_spreadsheet_using_geo_accession')
+    def test_get_spreadsheet_using_invalid_geo(self, mock_create_spreadsheet_using_geo_accession):
+        # given
+        mock_workbook = MagicMock()
+        mock_create_spreadsheet_using_geo_accession.return_value = mock_workbook
+        geo_accession = 'NoAccessionHere'
+
+        with _app.test_client() as app:
+            # when
+            response = app.post(f'import-geo?accession={geo_accession}')
+
+            # then
+            mock_create_spreadsheet_using_geo_accession.assert_not_called()
+            self.assertEqual(400, response.status_code)
+
+    @patch('broker.import_geo.routes.geo_to_hca.create_spreadsheet_using_geo_accession')
+    def test_get_spreadsheet_using_geo(self, mock_create_spreadsheet_using_geo_accession):
         # given
         mock_workbook = MagicMock()
         mock_create_spreadsheet_using_geo_accession.return_value = mock_workbook
@@ -18,7 +34,7 @@ class ExportToSpreadsheetUsingGeoTestCase(TestCase):
 
         with _app.test_client() as app:
             # when
-            response = app.get(f'geo-accession/spreadsheet?accession={geo_accession}')
+            response = app.post(f'import-geo?accession={geo_accession}')
 
             # then
             mock_create_spreadsheet_using_geo_accession.assert_called_with(geo_accession)

--- a/test/unit/geo_accession/test_new_spreadsheet_using_geo.py
+++ b/test/unit/geo_accession/test_new_spreadsheet_using_geo.py
@@ -26,7 +26,7 @@ class GetSpreadsheetUsingGeoTestCase(TestCase):
             self.assertEqual(400, response.status_code)
 
     @patch('broker.import_geo.routes.geo_to_hca.create_spreadsheet_using_geo_accession')
-    def test_get_spreadsheet_using_geo(self, mock_create_spreadsheet_using_geo_accession):
+    def test_get_spreadsheet_using_valid_geo(self, mock_create_spreadsheet_using_geo_accession):
         # given
         mock_workbook = MagicMock()
         mock_create_spreadsheet_using_geo_accession.return_value = mock_workbook


### PR DESCRIPTION
- Added geo_to_hca as a python dependency to the broker
- created the end point `broker_url/geo-accession/spreadsheet?geo-accession<geo_accession>` that returns an HCA metadata spreadsheet using the geo accession, for example: 

`<broker_url>/geo-accession/spreadsheet?accession=GSE97168`

see dcp-142