### PR TITLE
DCP 600: Fix issue with token being reset

### DIFF
--- a/broker/submissions/export_to_spreadsheet_service.py
+++ b/broker/submissions/export_to_spreadsheet_service.py
@@ -20,7 +20,6 @@ class ExportToSpreadsheetService:
         self.logger = logging.getLogger(__name__)
 
     def export(self, submission_uuid: str):
-        self.ingest_api.unset_token()
         entity_dict = self.data_collector.collect_data_by_submission_uuid(submission_uuid)
         entity_list = list(entity_dict.values())
         flattened_json = self.downloader.convert_json(entity_list)

--- a/broker/upload/routes.py
+++ b/broker/upload/routes.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 from flask import Blueprint, current_app, request
 from flask_cors import cross_origin
+from ingest.api.ingestapi import IngestApi
 from ingest.importer.importer import XlsImporter
 
 from broker.common.util import response_json
@@ -25,8 +26,9 @@ class UploadResponse:
 @cross_origin()
 def upload_spreadsheet():
     storage_service = SpreadsheetStorageService(current_app.SPREADSHEET_STORAGE_DIR)
-    importer = XlsImporter(current_app.ingest_api)
-    spreadsheet_upload_svc = SpreadsheetUploadService(current_app.ingest_api, storage_service, importer)
+    ingest_api = IngestApi()  # always create a new object for importing as it needs to use user token
+    importer = XlsImporter(ingest_api)
+    spreadsheet_upload_svc = SpreadsheetUploadService(ingest_api, storage_service, importer)
 
     token = request.headers.get('Authorization')
     request_file = request.files['file']


### PR DESCRIPTION
ebi-ait/dcp-ingest-central#600

Exporting/Downloading should use the app's ingest API object without a token ( app.ingest_api )

Importing should always create a new instance of the ingest API object as it should be using the user's jwt token https://github.com/ebi-ait/ingest-broker/blob/279d6c9d4e08dbf355eac48014e63bb9da017467/broker/service/spreadsheet_upload_service.py#L65

Exporting/Downloading and Importing now uses different instances of ingest_api obj