### PR TITLE
Remove token prior to creating entities

### DIFF
--- a/broker/service/spreadsheet_upload_service.py
+++ b/broker/service/spreadsheet_upload_service.py
@@ -25,7 +25,7 @@ class SpreadsheetUploadService:
         is_update = params.get('isUpdate')
         update_project = params.get('updateProject')
 
-        self._validate_token_exists(token)
+        self._set_token(token)
         submission_resource = self._create_or_get_submission(submission_uuid)
 
         submission_uuid = submission_resource["uuid"]["uuid"]
@@ -59,7 +59,7 @@ class SpreadsheetUploadService:
             submission_resource = self.ingest_api.create_submission()
         return submission_resource
 
-    def _validate_token_exists(self, token):
+    def _set_token(self, token):
         if token is None:
             raise SpreadsheetUploadError(401, "An authentication token must be supplied when uploading a spreadsheet")
         self.ingest_api.set_token(token)

--- a/broker/service/spreadsheet_upload_service.py
+++ b/broker/service/spreadsheet_upload_service.py
@@ -32,6 +32,11 @@ class SpreadsheetUploadService:
         submission_url = submission_resource["_links"]["self"]["href"]
         filename = secure_filename(request_file.filename)
 
+        # Unset token before creating/updating entities
+        # This is temporary until we have refresh token support
+        # See dcp-618
+        self.ingest_api.unset_token()
+
         if is_update:
             path = self._store_spreadsheet_updates(filename, request_file, submission_uuid)
             thread = threading.Thread(target=self.upload_updates, args=(submission_url, path))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-Cors==3.0.3
 itsdangerous==0.24
 MarkupSafe==1.1
 werkzeug>=0.15.3
--e git+https://github.com/ebi-ait/ingest-client.git@7fd3c25#egg=hca_ingest
+-e git+https://github.com/ebi-ait/ingest-client.git@94d54df#egg=hca_ingest
 jsonpickle~=1.2
 expiringdict==1.1.4
 jsonpath-rw


### PR DESCRIPTION
dcp-618

With large spreadsheets, the token may expire during the entity creation process. We don't actually need the user on entities and it gets removed by the validator later anyway so we can just remove the token from these requests. This just unsets the token so that it does not get sent along with the request.

Obviously a better solution would be to use refresh tokens but we don't have those with Elixir yet so I left a comment explaining.